### PR TITLE
refresh_examples.py: adjustment for vmware_rest

### DIFF
--- a/gouttelette/cmd/refresh_examples.py
+++ b/gouttelette/cmd/refresh_examples.py
@@ -5,6 +5,7 @@ import collections
 import io
 from pathlib import Path
 from typing import Dict, List, Any, Union
+import re
 import ruamel.yaml
 import yaml
 
@@ -64,13 +65,23 @@ def get_tasks(target_dir: Path, play: str = "main.yml") -> List[TaskType]:
     return tasks
 
 
-def naive_variable_from_jinja2(raw: str) -> Union[None | str]:
-    jinja2_string = raw.strip(" }{}")
+def naive_variable_from_jinja2(raw: str) -> Union[None, str]:
+    jinja2_string = raw.strip(" ")
+
     if "lookup(" in jinja2_string:
         return None
+
+    if m := re.search(r"^{{\s+(.*?)\s+}}$", jinja2_string):
+        jinja2_string = m.group(1)
+    if m := re.search(r"^\((.*)\).*", jinja2_string):
+        jinja2_string = m.group(1)
+    if m := re.search(r".*{{\s*(\S*)\s*}}.*", jinja2_string):
+        jinja2_string = m.group(1)
     if jinja2_string.startswith("not "):
         jinja2_string = jinja2_string[4:]
     variable = jinja2_string.split(".")[0]
+    if re.search("[/:]", variable):
+        return None
     if variable == "item":
         return None
     return variable
@@ -130,6 +141,10 @@ def extract(tasks: List[TaskType], collection_name: str) -> Dict[str, Any]:
             else:
                 registers[task["register"]] = depends_on + [task]
 
+        if "ansible.builtin.set_fact" in task:
+            for fact_name in task["ansible.builtin.set_fact"]:
+                registers[fact_name] = depends_on + [task]
+
         if "set_fact" in task:
             for fact_name in task["set_fact"]:
                 registers[fact_name] = depends_on + [task]
@@ -178,11 +193,13 @@ def inject(
         )
         new_content = ""
         in_examples_block = False
+        closing_pattern = None
         for l in module_path.read_text().split("\n"):
-            if l == "EXAMPLES = r'''":
+            if m := re.search(r"^EXAMPLES\s+=\s+(|r)('{3}|\"{3})$", l):
+                closing_pattern = m.group(2)
                 in_examples_block = True
                 new_content += l + "\n" + examples_section_to_inject.lstrip("\n")
-            elif in_examples_block and l == "'''":
+            elif closing_pattern and l == closing_pattern:
                 in_examples_block = False
                 new_content += l + "\n"
             elif in_examples_block:
@@ -193,6 +210,8 @@ def inject(
             raise ContentInjectionFailure(
                 "The closing of the EXAMPLES block was not found."
             )
+        if closing_pattern is None:
+            raise ContentInjectionFailure("The EXAMPLES block was not updated.")
         new_content = new_content.rstrip("\n") + "\n"
         print(f"Updating {module_name}")
         module_path.write_text(new_content)
@@ -211,10 +230,14 @@ def main() -> None:
     args = parser.parse_args()
     galaxy_file = args.target_dir / "galaxy.yml"
     galaxy = yaml.safe_load(galaxy_file.open())
+    gouttelette_file = args.target_dir / "gouttelette.yml"
+    gouttelette = yaml.safe_load(gouttelette_file.open())
     collection_name = f"{galaxy['namespace']}.{galaxy['name']}"
     tasks = []
-    test_scenarios_dir = args.target_dir / "tests" / "integration" / "targets"
-    for scenario_dir in test_scenarios_dir.glob("*"):
+    test_scenarios_dirs = [
+        args.target_dir / Path(i) for i in gouttelette.get("load_examples_from", [])
+    ]
+    for scenario_dir in test_scenarios_dirs:
         if not scenario_dir.is_dir():
             continue
         if scenario_dir.name.startswith("setup_"):

--- a/tests/cmd/test_refresh_examples.py
+++ b/tests/cmd/test_refresh_examples.py
@@ -47,8 +47,11 @@ naive_variables = [
     ("{{ foo_bar }}", "foo_bar"),
     ("{{ not foo_bar }}", "foo_bar"),
     ("{{ foo_bar.key }}", "foo_bar"),
+    ("foobar{{ bar.key }}", "bar"),
     ("{{ item }}", None),
     ("{{ lookup('lookup are not supported') }}", None),
+    ("https://foo.bar", None),
+    ("(lib_items.value|first).id", "lib_items"),
 ]
 
 

--- a/tests/cmd/test_refresh_examples.py
+++ b/tests/cmd/test_refresh_examples.py
@@ -47,11 +47,20 @@ naive_variables = [
     ("{{ foo_bar }}", "foo_bar"),
     ("{{ not foo_bar }}", "foo_bar"),
     ("{{ foo_bar.key }}", "foo_bar"),
+    ("{{ aws_region }}{{ item.zone }}", "aws_region"),
     ("foobar{{ bar.key }}", "bar"),
     ("{{ item }}", None),
     ("{{ lookup('lookup are not supported') }}", None),
     ("https://foo.bar", None),
-    ("(lib_items.value|first).id", "lib_items"),
+    (
+        '{{ (lib_items.value|selectattr("name", "equalto", "golden_image")|first).id }}',
+        "lib_items",
+    ),
+    # This is too complicated. Let's just ignore it.
+    (
+        "{{ {} | combine({ my_new_disk.id: {'policy': my_storage_policy.policy, 'type': 'USE_SPECIFIED_POLICY'} }) }}",
+        None,
+    ),
 ]
 
 
@@ -93,7 +102,7 @@ def test_extract_identify_valid_block():
         }
     }
 
-    assert refresh_examples.extract(my_tasks, "foo.bar") == expectation
+    assert refresh_examples.extract(my_tasks, "foo.bar", []) == expectation
 
 
 def test_extract_with_dependencies():
@@ -138,7 +147,7 @@ def test_extract_with_dependencies():
         }
     }
 
-    assert refresh_examples.extract(my_tasks, "foo.bar") == expectation
+    assert refresh_examples.extract(my_tasks, "foo.bar", []) == expectation
 
 
 def test_extract_missing_dependency():
@@ -152,7 +161,20 @@ def test_extract_missing_dependency():
         },
     ]
     with pytest.raises(refresh_examples.MissingDependency):
-        refresh_examples.extract(my_tasks, "foo.bar")
+        refresh_examples.extract(my_tasks, "foo.bar", [])
+
+
+def test_extract_with_dont_look_up_vars():
+    my_tasks = [
+        {
+            "name": "This would be a great example",
+            "foo.bar.my_module": {
+                "first_param": "{{ a_fact }}",
+                "second_param": "{{ my_stuff }}",
+            },
+        },
+    ]
+    refresh_examples.extract(my_tasks, "foo.bar", ["a_fact", "my_stuff"])
 
 
 def test_flatten_module_examples():


### PR DESCRIPTION
- extend the capability of the naive parser
- support `ansible.builtin.set_fact`
- identify EXAMPLES blocks starting with `r"""`
- read the playbook to source from the new `gouttelette.yml` configuration file
