### PR TITLE
get_module_from_config: always return a dict

### DIFF
--- a/gouttelette/utils.py
+++ b/gouttelette/utils.py
@@ -67,13 +67,13 @@ def indent(text_block: str, indent: int = 0) -> str:
     return result
 
 
-def get_module_from_config(module: str, generator: str) -> Any:
+def get_module_from_config(module: str, generator: str) -> dict[str, Any]:
 
     raw_content = pkg_resources.resource_string(generator, "config/modules.yaml")
     for i in yaml.safe_load(raw_content):
         if module in i:
-            return i[module]
-    return {}
+            return i[module] or {}
+    raise KeyError
 
 
 def python_type(value: str) -> str:
@@ -95,10 +95,12 @@ class UtilsBase:
     name: str
 
     def is_trusted(self, generator: str) -> bool:
-        if get_module_from_config(self.name, generator):
+        try:
+            get_module_from_config(self.name, generator)
             return True
-        print(f"- do not build: {self.name}")
-        return False
+        except KeyError:
+            print(f"- do not build: {self.name}")
+            return False
 
     def write_module(self, target_dir: Path, content: str) -> None:
         module_dir = target_dir / "plugins" / "modules"

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
+import pkg_resources
 from gouttelette import utils
+
+from unittest.mock import patch
 
 
 def test_format_documentaion():
@@ -47,3 +50,14 @@ def test_python_type():
     assert utils.python_type("boolean") == "bool"
     assert utils.python_type(["object", "string"]) == "dict"
     assert utils.python_type(["string", "object"]) == "str"
+
+
+@patch("pkg_resources.resource_string")
+def test_UtilsBase_is_trusted(m_resource_string):
+    m_resource_string.return_value = "---\n- foo:\n- bar:\n  some: key\n"
+    module = utils.UtilsBase("no-trusted-pantoute")
+    assert module.is_trusted("a-generator") is False
+    module = utils.UtilsBase("foo")
+    assert module.is_trusted("a-generator") is True
+    module = utils.UtilsBase("bar")
+    assert module.is_trusted("a-generator") is True


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware.vmware_rest/pull/377

`get_module_from_config` was returning an empty dict if the
configuration for one module just hold an empty dict. This
was also the case when a module was not present in the configuration.

As a consequence it was not possible to make the difference between
those that were actually present (trusted) and the others.
