### PR TITLE
tox/pytest: accept argument from the CLI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ description = Run the test-suite and generate a HTML coverage report
 deps =
   pytest-cov
   pytest
-commands = pytest tests -vvv
+commands = pytest -vvv {posargs:tests}
 
 [testenv:clean]
 deps = coverage


### PR DESCRIPTION
Add the ability to specify a given test through the CLI. e.g:

```
tox -e py3 tests/unit/cmd/test_generator.py::test_generate_documentation
```
