### PR TITLE
tox/mypy: ignore the test files

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
   types-PyYAML
   types-setuptools
 commands =
-  mypy --strict gouttelette/
+  mypy --strict --exclude '/test_.*.py$' --exclude 'gouttelette/module_utils/' gouttelette
 
 [testenv:black]
 deps =


### PR DESCRIPTION
Ignore the test files and the module_utils directory.